### PR TITLE
Schema updates

### DIFF
--- a/getdata.php
+++ b/getdata.php
@@ -6,8 +6,8 @@ final class GetData implements \JSONSerializable, \Iterator, Interfaces\InputDat
 	use Traits\Singleton;
 	use Traits\InputData;
 
-	final public function __construct()
+	final public function __construct(array $data = null)
 	{
-		static::_setInputData($_GET);
+		$this->_setInputData(isset($data) ? $data : $_GET);
 	}
 }

--- a/interfaces/inputdata.php
+++ b/interfaces/inputdata.php
@@ -12,7 +12,7 @@ interface InputData
 
 	public function has(string ...$keys): bool;
 
-	public function __invoke(string $key, bool $escape = true);
+	public function __invoke(...$args);
 
 	public function __get(string $key);
 

--- a/postdata.php
+++ b/postdata.php
@@ -6,29 +6,31 @@ class PostData implements \JSONSerializable, \Iterator, Interfaces\InputData
 	use Traits\Singleton;
 	use Traits\InputData;
 
-	final public function __construct()
+	final public function __construct(array $data = null)
 	{
-		if (array_key_exists('CONTENT_TYPE', $_SERVER)) {
+		if (isset($data)) {
+			$this->_setInputData($data);
+		} elseif (array_key_exists('CONTENT_TYPE', $_SERVER)) {
 			switch (strtolower($_SERVER['CONTENT_TYPE'])) {
 				case 'application/json':
 				case 'text/json':
-					static::_setInputData(json_decode(file_get_contents('php://input'), true));
+					$this->_setInputData(json_decode(file_get_contents('php://input'), true));
 					break;
 				case 'application/csp-report':
 					$report = json_decode(file_get_contents('php://input'), true);
 					if (array_key_exists('csp-report', $report)) {
-						static::_setInputData($report['csp-report']);
+						$this->_setInputData($report['csp-report']);
 					}
 					break;
 				case 'text/plain':
 				case 'application/text':
-					static::_setInputData(['text' => file_get_contents('php://input')]);
+					$this->_setInputData(['text' => file_get_contents('php://input')]);
 					break;
 				default:
-					static::_setInputData($_POST);
+					$this->_setInputData($_POST);
 			}
 		} else {
-			static::_setInputData($_POST);
+			$this->_setInputData($_POST);
 		}
 	}
 }

--- a/schema/abstracts/intangible.php
+++ b/schema/abstracts/intangible.php
@@ -1,6 +1,6 @@
 <?php
 namespace shgysk8zer0\PHPAPI\Schema\Abstracts;
-use \shgysk8zer0\PHPAPI\Schea\{Thing};
+use \shgysk8zer0\PHPAPI\Schema\{Thing};
 
 abstract class Intangible extends Thing
 {

--- a/schema/abstracts/schema.php
+++ b/schema/abstracts/schema.php
@@ -5,11 +5,12 @@ use \JSONSerializable;
 use \shgysk8zer0\PHPAPI\{PDO, URL, Headers};
 use \shgysk8zer0\PHPAPI\Interfaces\{InputData};
 use \shgysk8zer0\PHPAPI\Schema\Interfaces\{Schema as SchemaInterface};
-use \shgysk8zer0\PHPAPI\Schema\Traits\{Schema as SchemaTrait};
+use \shgysk8zer0\PHPAPI\Schema\Traits\{Schema as SchemaTrait, UUID};
 
 abstract class Schema implements JSONSerializable, SchemaInterface
 {
 	use SchemaTrait;
+	use UUID;
 
 	const CONTEXT = 'https://schema.org/';
 
@@ -72,8 +73,7 @@ abstract class Schema implements JSONSerializable, SchemaInterface
 		if (isset(static::$_pdo)) {
 			$sql     = sprintf('SELECT * FROM `%s` WHERE `id` = :id LIMIT 1;', $this::TYPE);
 			$stm     = static::$_pdo->prepare($sql);
-			$stm->id = $id;
-			$stm->execute();
+			$stm->execute([':id' => $id]);
 			return $stm->fetchObject();
 		} else {
 			return new \StdClass();

--- a/schema/abstracts/schema.php
+++ b/schema/abstracts/schema.php
@@ -3,6 +3,7 @@ namespace shgysk8zer0\PHPAPI\Schema\Abstracts;
 
 use \JSONSerializable;
 use \shgysk8zer0\PHPAPI\{PDO, URL, Headers};
+use \shgysk8zer0\PHPAPI\Interfaces\{InputData};
 use \shgysk8zer0\PHPAPI\Schema\Interfaces\{Schema as SchemaInterface};
 use \shgysk8zer0\PHPAPI\Schema\Traits\{Schema as SchemaTrait};
 

--- a/schema/abstracts/schema.php
+++ b/schema/abstracts/schema.php
@@ -21,7 +21,7 @@ abstract class Schema implements JSONSerializable, SchemaInterface
 	public function __construct(int $id = null)
 	{
 		if (isset($id)) {
-			if ($data = $this->_init($id)) {
+			if ($data = $this->_init($id) and isset($data->id)) {
 				$this->_setData($data);
 			}
 		}

--- a/schema/event.php
+++ b/schema/event.php
@@ -1,0 +1,57 @@
+<?php
+namespace shgysk8zer0\PHPAPI\Schema;
+
+use \StdClass;
+use \DateTime;
+
+class Event extends Thing
+{
+	const TYPE = 'Event';
+
+	protected function _setData(StdClass $data)
+	{
+		$data->id = intval($data->id);
+		$this->setName($data->name);
+		$this->setStartDate(new DateTime($data->startDate));
+
+		if (isset($data->endDate)) {
+			$this->setEndDate(new DateTime($data->endDate));
+		}
+
+		if (isset($data->location)) {
+			$this->setLocation(new Place($data->location));
+		}
+
+		if (isset($data->description)) {
+			$this->setDescription($data->description);
+		}
+
+		if (isset($data->organizer)) {
+			$this->setOrganizer(new Person($data->organizer));
+		}
+
+		if (isset($data->image)) {
+			$this->setImage(new ImageObject($data->image));
+		}
+	}
+
+	public function setLocation(place $place)
+	{
+		$this->_set('location', $place);
+	}
+
+	public function setStartDate(DateTime $dtime)
+	{
+		$this->_set('startdate', $dtime->format(DateTime::W3C));
+	}
+
+	public function setEndDate(DateTime $dtime)
+	{
+		$this->_set('enddate', $dtime->format(DateTime::W3C));
+	}
+
+	public function setOrganizer(Person $organizer)
+	{
+		$this->_set('organizer', $organizer);
+	}
+}

--- a/schema/event.php
+++ b/schema/event.php
@@ -10,7 +10,8 @@ class Event extends Thing
 
 	protected function _setData(StdClass $data)
 	{
-		$data->id = intval($data->id);
+		$this->_setId($data->id);
+		$this->_set('guid', static::generateUuid());
 		$this->setName($data->name);
 		$this->setStartDate(new DateTime($data->startDate));
 

--- a/schema/event.php
+++ b/schema/event.php
@@ -11,7 +11,7 @@ class Event extends Thing
 	protected function _setData(StdClass $data)
 	{
 		$this->_setId($data->id);
-		$this->_set('guid', static::generateUuid());
+		$this->_setUuid(static::generateUuid());
 		$this->setName($data->name);
 		$this->setStartDate(new DateTime($data->startDate));
 

--- a/schema/geocoordinates.php
+++ b/schema/geocoordinates.php
@@ -8,7 +8,7 @@ class GeoCoordinates extends \shgysk8zer0\PHPAPI\Schema\Abstracts\Intangible
 
 	protected function _setData(\StdClass $data)
 	{
-		$data->id = intval($data->id);
+		$this->_setId($data->id);
 
 		$this->setLongitude($data->longitude);
 		$this->setLatitude($data->latitude);

--- a/schema/geocoordinates.php
+++ b/schema/geocoordinates.php
@@ -1,0 +1,48 @@
+<?php
+namespace shgysk8zer0\PHPAPI\Schema;
+
+class GeoCoordinates extends \shgysk8zer0\PHPAPI\Schema\Abstracts\Intangible
+{
+	const TYPE = 'GeoCoordinates';
+	const DEFAULT_DIST_UNITS = 'ft';
+
+	protected function _setData(\StdClass $data)
+	{
+		$data->id = intval($data->id);
+
+		$this->setLongitude($data->longitude);
+		$this->setLatitude($data->latitude);
+
+		if (isset($data->elevation)) {
+			$this->setElevation($data->elevation);
+		}
+
+		if (isset($data->name)) {
+			$this->setName($data->name);
+		}
+	}
+
+	public function setLongitude(float $lng)
+	{
+		$this->_set('longitude', $lng);
+	}
+
+	public function setLatitude(float $lat)
+	{
+		$this->_set('latitude', $lat);
+	}
+
+	public function setElevation(int $elevation, string $units = self::DEFAULT_DIST_UNITS)
+	{
+		if ($units !== 'm') {
+			switch($units) {
+				case 'ft':
+					$elevation *= 0.3048;
+					break;
+				default:
+					throw new \InvalidArgumentException(sprintf('Unsupported units, "%s"', $units));
+			}
+		}
+		$this->_set('elevation', intval($elevation));
+	}
+}

--- a/schema/imageobject.php
+++ b/schema/imageobject.php
@@ -9,7 +9,7 @@ class ImageObject extends Thing
 
 	protected function _setData(\StdClass $data)
 	{
-		$data->id = intval($data->id);
+		$this->_setId($data->id);
 		$this->setUrl($data->url);
 
 		if (isset($data->height)) {

--- a/schema/imageobject.php
+++ b/schema/imageobject.php
@@ -1,0 +1,125 @@
+<?php
+namespace shgysk8zer0\PHPAPI\Schema;
+use \DateTime;
+use \StdClass;
+
+class ImageObject extends Thing
+{
+	const TYPE = 'ImageObject';
+
+	protected function _setData(\StdClass $data)
+	{
+		$data->id = intval($data->id);
+		$this->setUrl($data->url);
+
+		if (isset($data->height)) {
+			$this->setHeight($data->height);
+		}
+
+		if (isset($data->width)) {
+			$this->setWidth($data->width);
+		}
+
+		if (isset($data->author)) {
+			$this->setAuthor(new Person($data->author));
+		}
+
+		if (isset($data->publisher)) {
+			$this->setPublisher($data->publisher);
+		}
+
+		if (isset($data->encodingFormat)) {
+			$this->setEncodingFormat($data->encodingFormat);
+		}
+
+		if (isset($data->caption)) {
+			$this->setCaption($data->caption);
+		}
+
+		$this->setIsFamilyFriendly($data->isFamilyFriendly === '1');
+		$this->setUploadDate(new DateTime($data->uploadDate));
+		$this->setDatePublished(new DateTime($data->datePublished));
+		$this->setDateModified(new DateTIme($data->dateModified));
+	}
+
+	public function setUrl(string $url)
+	{
+		$this->_set('url', $url);
+	}
+
+	public function setWidth(int $width)
+	{
+		$this->_set('width', $width);
+	}
+
+	public function setHeight(int $height)
+	{
+		$this->_set('height', $height);
+	}
+
+	public function setContentSize(int $value, string $units = 'kB')
+	{
+		// @TODO Unit conversion
+		$this->_set('contentSize', $value);
+	}
+
+	public function setEncodingFormat(string $format)
+	{
+		$this->_set('encodingFormat', $format);
+	}
+
+	public function setCaption(string $caption)
+	{
+		$this->_set('caption', $caption);
+	}
+
+	public function setAuthor(Person $author)
+	{
+		$this->_set('author', $author);
+	}
+
+	public function setPublisher(Organization $publisher)
+	{
+		$this->_set('publisher', $publisher);
+	}
+
+	public function setIsFamilyFriendly(bool $friendly)
+	{
+		$this->_set('isFamilyFriendly', $friendly);
+	}
+
+	public function setKeywords(string ...$keywords)
+	{
+		$this->_set('keywords', join($keywords, ', '));
+	}
+
+	public function setDateModified(DateTime $date)
+	{
+		$this->_set('dateModified', $date->format(\DateTime::W3C));
+	}
+
+	public function setUploadDate(DateTime $date)
+	{
+		$this->_set('uploadDate', $date->format(\DateTime::W3C));
+	}
+
+	public function setDatePublished(DateTime $date)
+	{
+		$this->_set('datePublished', $date->format(\DateTime::W3C));
+	}
+
+	public function setCopyrightYear(int $year)
+	{
+		$this->_set('copyrightYear', $year);
+	}
+
+	public function setCopyrightHolder(Organization $holder)
+	{
+		$this->_set('copyrightHolder', $holder);
+	}
+
+	public function setContentLocation(Place $location)
+	{
+		$this->_set('contentLocation', $location);
+	}
+}

--- a/schema/interfaces/schema.php
+++ b/schema/interfaces/schema.php
@@ -1,10 +1,12 @@
 <?php
 namespace shgysk8zer0\PHPAPI\Schema\Interfaces;
 use \shgysk8zer0\PHPAPI\{PDO};
+use \shgysk8zer0\PHPAPI\Interfaces\{InputData};
+use \shgysk8zer0\PHPAPI\Schema\{Thing};
 
 interface Schema
 {
-	public function create(): bool;
+	public static function create(InputData $input): Thing;
 
 	public function delete(): bool;
 

--- a/schema/interfaces/schema.php
+++ b/schema/interfaces/schema.php
@@ -10,5 +10,7 @@ interface Schema
 
 	public function delete(): bool;
 
+	public static function generateUuid(): string;
+
 	public static function setPDO(PDO $pdo);
 }

--- a/schema/organization.php
+++ b/schema/organization.php
@@ -7,12 +7,55 @@ class Organization extends Thing
 
 	use Traits\Search;
 
+	public function setAddress(PostalAddress $addr)
+	{
+		$this->_set('address', $addr);
+	}
+
+	public function setEmail(string $email)
+	{
+		if (filter_var($email, FILTER_VALIDATE_EMAIL)) {
+			$this->_set('email', $email);
+		} else {
+			throw new \InvalidArgumentException(sprintf('"%s" is not a valid email', $email));
+		}
+	}
+
+	public function setUrl(string $url)
+	{
+		if (filter_var($url, FILTER_VALIDATE_URL)) {
+			$this->_set('url', $url);
+		} else {
+			throw new \InvalidArgumentException(sprintf('"%s" is not a valid URL', $url));
+		}
+	}
+
+	public function setTelephone(string $phone)
+	{
+		$this->_set('telephone', $phone);
+	}
+
+	public function setLogo(ImageObject $logo)
+	{
+		$this->_set('logo', $logo);
+	}
+
 	protected function _setData(\StdClass $data)
 	{
 		$data->id = intval($data->id);
+
 		if (isset($data->address)) {
 			$data->address = new PostalAddress($data->address);
 		}
+
+		if (isset($data->logo)) {
+			$data->logo = new ImageObject($data->logo);
+		}
+
+		if (isset($data->image)) {
+			$data->image = new ImageObject($data->image);
+		}
+
 		$this->_setDataObject($data);
 	}
 }

--- a/schema/organization.php
+++ b/schema/organization.php
@@ -44,18 +44,34 @@ class Organization extends Thing
 	{
 		$data->id = intval($data->id);
 
-		if (isset($data->address)) {
-			$data->address = new PostalAddress($data->address);
+		$this->setName($data->name);
+
+		if (isset($data->description)) {
+			$this->setDescription($data->description);
 		}
 
-		if (isset($data->logo)) {
-			$data->logo = new ImageObject($data->logo);
+		if (isset($data->address)) {
+			$this->setAddress(new PostalAddress($data->address));
+		}
+
+		if (isset($data->email)) {
+			$this->setEmail($data->email);
+		}
+
+		if (isset($data->telephone)) {
+			$this->setTelephone($data->telephone);
+		}
+
+		if (isset($data->faxNumber)) {
+			$this->setFaxNumber($data->faxNumber);
 		}
 
 		if (isset($data->image)) {
-			$data->image = new ImageObject($data->image);
+			$this->setImage(new ImageObject($data->image));
 		}
 
-		$this->_setDataObject($data);
+		if (isset($data->logo)) {
+			$this->setLogo(new ImageObject($data->logo));
+		}
 	}
 }

--- a/schema/person.php
+++ b/schema/person.php
@@ -16,7 +16,7 @@ class Person extends Thing
 		return static::_simpleSearch('familyName', $name, $limit, $offset);
 	}
 
-	public static function create(InputData $input): self
+	public static function create(InputData $input): Thing
 	{
 		$person = new self();
 

--- a/schema/person.php
+++ b/schema/person.php
@@ -19,7 +19,8 @@ class Person extends Thing
 	public static function create(InputData $input): Thing
 	{
 		$person = new self();
-
+		$person->_setUuid(static::generateUuid());
+		$this->_setId($data->id);
 		$person->setName($input->get('givenName'));
 
 		if ($input->has('additionalName')) {

--- a/schema/person.php
+++ b/schema/person.php
@@ -1,6 +1,9 @@
 <?php
 namespace shgysk8zer0\PHPAPI\Schema;
 
+use \shgysk8zer0\PHPAPI\Schema\{PostalAddress};
+use \DateTime;
+
 class Person extends Thing
 {
 	const TYPE = 'Person';
@@ -14,12 +17,63 @@ class Person extends Thing
 	protected function _setData(\StdClass $data)
 	{
 		$data->id = intval($data->id);
+
 		if (isset($data->address)) {
 			$data->address = new PostalAddress($data->address);
 		}
+
 		if (isset($data->worksFor)) {
 			$data->worksFor = new Organization($data->worksFor);
 		}
+
+		if (isset($data->image)) {
+			$data->image = new ImageObject($data->image);
+		}
+
 		$this->_setDataObject($data);
+	}
+
+	public function setGivenName(string $first)
+	{
+		$this->_set('givenName', $first);
+	}
+
+	public function setAdditionalName(string $middle)
+	{
+		$this->_set('additionalName', $middle);
+	}
+
+	public function setFamilyName(string $last)
+	{
+		$this->_set('familyName', $last);
+	}
+
+	public function setEmail(string $email)
+	{
+		if (filter_var($email, FILTER_VALIDATE_EMAIL)) {
+			$this->_set('email', $email);
+		} else {
+			throw new \InvalidArgumentException(sprintf('"%s" is not a valid email address', $email));
+		}
+	}
+
+	public function setWorksFor(Organization $org)
+	{
+		$this->_set('worksFor', $org);
+	}
+
+	public function setTelephone(string $phone)
+	{
+		$this->_set('telephone', $phone);
+	}
+
+	public function setAddress(PostalAddress $addr)
+	{
+		$this->_set('address', $addr);
+	}
+
+	public function setBirthDate(DateTime $bday)
+	{
+		$this->_set('birthDate', $bday->format('Y-m-d'));
 	}
 }

--- a/schema/person.php
+++ b/schema/person.php
@@ -1,17 +1,46 @@
 <?php
 namespace shgysk8zer0\PHPAPI\Schema;
 
+use \shgysk8zer0\PHPAPI\Interfaces\{InputData};
 use \shgysk8zer0\PHPAPI\Schema\{PostalAddress};
 use \DateTime;
 
 class Person extends Thing
 {
 	const TYPE = 'Person';
+
 	use Traits\Search;
 
 	final public static function searchByFamilyName(string $name, int $limit = 10, int $offset = 0): array
 	{
 		return static::_simpleSearch('familyName', $name, $limit, $offset);
+	}
+
+	public static function create(InputData $input): self
+	{
+		$person = new self();
+
+		$person->setName($input->get('givenName'));
+
+		if ($input->has('additionalName')) {
+			$person->setAdditionalName($input->get('additionalName'));
+		}
+
+		$person->setFamilyName($input->get('familyName'));
+
+		if ($input->has('email')) {
+			$person->setEmail($input->get('email'));
+		}
+
+		if ($input->has('telephone')) {
+			$person->setTelephone($input->get('telephone'));
+		}
+
+		if ($input->has('birthDate')) {
+			$person->set('birthDate', new DateTime($input->get('birthDate')));
+		}
+
+		return $person;
 	}
 
 	protected function _setData(\StdClass $data)

--- a/schema/place.php
+++ b/schema/place.php
@@ -1,0 +1,51 @@
+<?php
+namespace shgysk8zer0\PHPAPI\Schema;
+
+class Place extends Thing
+{
+	const TYPE = 'Place';
+
+	protected function _setData(\StdClass $data)
+	{
+		if (isset($data->name)) {
+			$this->setName($data->name);
+		}
+
+		if (isset($data->description)) {
+		}
+
+		if (isset($data->address)) {
+			$this->setAddress(new PostalAddress($data->address));
+		}
+
+		if (isset($data->geo)) {
+			$this->setGeo(new GeoCoordinates($data->geo));
+		}
+
+		if (isset($data->image)) {
+			$this->setImage(new ImageObject($data->image));
+		}
+
+		$this->setPublicAccess($data->publicAccess === '1');
+	}
+
+	public function setAddress(PostalAddress $address)
+	{
+		$this->_set('address', $address);
+	}
+
+	public function setGeo(GeoCoordinates $geo)
+	{
+		$this->_set('geo', $geo);
+	}
+
+	public function setPublicAccess(bool $access)
+	{
+		$this->_set('publicAcces', $access);
+	}
+
+	public function setImage(ImageObject $img)
+	{
+		$this->_set('image', $img);
+	}
+}

--- a/schema/place.php
+++ b/schema/place.php
@@ -7,6 +7,7 @@ class Place extends Thing
 
 	protected function _setData(\StdClass $data)
 	{
+		$this->_setId($data->id);
 		if (isset($data->name)) {
 			$this->setName($data->name);
 		}

--- a/schema/postaladdress.php
+++ b/schema/postaladdress.php
@@ -7,6 +7,8 @@ class PostalAddress extends Thing
 
 	protected function _setData(\StdClass $data)
 	{
+		$this->_setId($data->id);
+
 		if (isset($data->streetAddress)) {
 			$this->setStreetAddress($data->streetAddress);
 		}

--- a/schema/postaladdress.php
+++ b/schema/postaladdress.php
@@ -5,9 +5,41 @@ class PostalAddress extends Thing
 {
 	const TYPE = 'PostalAddress';
 
+	protected function _setData(\StdClass $data)
+	{
+		if (isset($data->streetAddress)) {
+			$this->setStreetAddress($data->streetAddress);
+		}
+
+		if (isset($data->postOfficeBoxNumber)) {
+			$this->setPostOfficeBoxNumber($data->postOfficeBoxNumber);
+		}
+
+		if (isset($data->addressLocality)) {
+			$this->setAddressLocality($data->addressLocality);
+		}
+
+		if (isset($data->addressRegion)) {
+			$this->setAddressRegion($data->addressRegion);
+		}
+
+		if (isset($data->postalCode)) {
+			$this->setPostalCode($data->postalCode);
+		}
+
+		if (isset($data->addressCountry)) {
+			$this->setAddressCountry($data->addressCountry);
+		}
+	}
+
 	public function setStreetAddress(string $address)
 	{
 		$this->_set('streetAddress', $address);
+	}
+
+	public function setPostOfficeBoxNumber(int $po_box)
+	{
+		$this->_set('postOfficeBoxNumber', $po_box);
 	}
 
 	public function setAddressLocality(string $city)

--- a/schema/postaladdress.php
+++ b/schema/postaladdress.php
@@ -4,4 +4,29 @@ namespace shgysk8zer0\PHPAPI\Schema;
 class PostalAddress extends Thing
 {
 	const TYPE = 'PostalAddress';
+
+	public function setStreetAddress(string $address)
+	{
+		$this->_set('streetAddress', $address);
+	}
+
+	public function setAddressLocality(string $city)
+	{
+		$this->_set('addressLocality', $city);
+	}
+
+	public function setAddressRegion(string $region)
+	{
+		$this->_set('addressRegion', $region);
+	}
+
+	public function setAddressCountry(string $country)
+	{
+		$this->_set('addressCountry', $country);
+	}
+
+	public function setPostalCode(int $postal_code)
+	{
+		$this->_set('postalCode', $postal_code);
+	}
 }

--- a/schema/thing.php
+++ b/schema/thing.php
@@ -45,11 +45,7 @@ class Thing extends Abstracts\Schema
 	public static function create(InputData $input): self
 	{
 		$thing = new self();
-		$this->_setUuid(static::generateUuid());
-
-		if ($input->has('image')) {
-			$thing->setImage(new ImageObject($input->get('image')));
-		}
+		$thing->_setUuid(static::generateUuid());
 
 		if ($input->has('name')) {
 			$thing->setName($input->get('name'));
@@ -59,12 +55,26 @@ class Thing extends Abstracts\Schema
 			$thing->setDescription($input->get('description'));
 		}
 
+		if ($input->has('image')) {
+			$thing->setImage(new ImageObject($input->get('image')));
+		}
+
 		return $thing;
 	}
 
 	protected function _setData(\StdClass $data)
 	{
-		$data->id = intval($data->id);
+		if (isset($data->name)) {
+			$this->setName($data->name);
+		}
+
+		if (isset($data->description)) {
+			$this->setDescrption($data->description);
+		}
+
+		if (isset($data->image)) {
+			$this->setImage(new ImageObject($data->image));
+		}
 		$this->_setDataObject($data);
 	}
 }

--- a/schema/thing.php
+++ b/schema/thing.php
@@ -19,7 +19,7 @@ class Thing extends Abstracts\Schema
 
 	final public function getId(): int
 	{
-		return $this->_get('id');
+		return $this->_getId();
 	}
 
 	final public function getName(): string
@@ -32,11 +32,6 @@ class Thing extends Abstracts\Schema
 		$this->_set('name', $name);
 	}
 
-	public function delete(): bool
-	{
-		return true;
-	}
-
 	public function setImage(ImageObject $img)
 	{
 		$this->_set('image', $img);
@@ -45,6 +40,26 @@ class Thing extends Abstracts\Schema
 	public function getImage(): ImageObject
 	{
 		return $this->_get('image');
+	}
+
+	public static function create(InputData $input): self
+	{
+		$thing = new self();
+		$this->_setUuid(static::generateUuid());
+
+		if ($input->has('image')) {
+			$thing->setImage(new ImageObject($input->get('image')));
+		}
+
+		if ($input->has('name')) {
+			$thing->setName($input->get('name'));
+		}
+
+		if ($input->has('description')) {
+			$thing->setDescription($input->get('description'));
+		}
+
+		return $thing;
 	}
 
 	protected function _setData(\StdClass $data)

--- a/schema/thing.php
+++ b/schema/thing.php
@@ -10,7 +10,7 @@ class Thing extends Abstracts\Schema
 		return $this->_get('description');
 	}
 
-	final public function setDescription(string $description): string
+	final public function setDescription(string $description)
 	{
 		$this->_set('description', $description);
 	}
@@ -38,6 +38,16 @@ class Thing extends Abstracts\Schema
 	public function delete(): bool
 	{
 		return true;
+	}
+
+	public function setImage(ImageObject $img)
+	{
+		$this->_set('image', $img);
+	}
+
+	public function getImage(): ImageObject
+	{
+		return $this->_get('image');
 	}
 
 	protected function _setData(\StdClass $data)

--- a/schema/thing.php
+++ b/schema/thing.php
@@ -1,6 +1,8 @@
 <?php
 namespace shgysk8zer0\PHPAPI\Schema;
 
+use \shgysk8zer0\PHPAPI\Interfaces\{InputData};
+
 class Thing extends Abstracts\Schema
 {
 	const TYPE = 'Thing';
@@ -28,11 +30,6 @@ class Thing extends Abstracts\Schema
 	final public function setName(string $name)
 	{
 		$this->_set('name', $name);
-	}
-
-	public function create(): bool
-	{
-		return true;
 	}
 
 	public function delete(): bool

--- a/schema/traits/schema.php
+++ b/schema/traits/schema.php
@@ -10,6 +10,30 @@ trait Schema
 
 	protected $_data = [];
 
+	protected $_id = 0;
+
+	protected $_uuid = '';
+
+	final protected function _setId(int $id)
+	{
+		$this->_id = $id;
+	}
+
+	final protected function _setUuid(string $uuid)
+	{
+		$this->_uuid = $uuid;
+	}
+
+	final protected function getUuid(): string
+	{
+		return $this->_uuid;
+	}
+
+	final protected function _getId(): int
+	{
+		return $this->_id;
+	}
+
 	final public static function setPDO(PDO $pdo)
 	{
 		static::$_pdo = $pdo;
@@ -18,6 +42,22 @@ trait Schema
 	public static function create(InputData $input): Thing
 	{
 		return new self();
+	}
+
+	public function delete(): bool
+	{
+		if ($this->_getId() !== 0) {
+			$sql = sprintf('DELETE FROM `%s` WHERE `id` = :id LIMIT 1;', $this::TYPE);
+			$stm = $this->_pdo->prepare($sql);
+
+			if ($stm->execute([':id' => $this->_getId()])) {
+				return $stm->rowCount() === 1;
+			} else {
+				return false;
+			}
+		} else {
+			return true;
+		}
 	}
 
 	final protected function _get(string $key)

--- a/schema/traits/schema.php
+++ b/schema/traits/schema.php
@@ -1,6 +1,8 @@
 <?php
 namespace shgysk8zer0\PHPAPI\Schema\Traits;
 use \shgysk8zer0\PHPAPI\{PDO};
+use \shgysk8zer0\PHPAPI\Interfaces\{InputData};
+use \shgysk8zer0\PHPAPI\Schema\{Thing};
 
 trait Schema
 {
@@ -11,6 +13,11 @@ trait Schema
 	final public static function setPDO(PDO $pdo)
 	{
 		static::$_pdo = $pdo;
+	}
+
+	public static function create(InputData $input): Thing
+	{
+		return new self();
 	}
 
 	final protected function _get(string $key)

--- a/schema/traits/schema.php
+++ b/schema/traits/schema.php
@@ -14,6 +14,14 @@ trait Schema
 
 	protected $_uuid = '';
 
+	public function __debugInfo(): array
+	{
+		$this->_data;
+		$data['id'] = $this->_id;
+		$data['uuid'] = $this->_uuid;
+		return $data;
+	}
+
 	final protected function _setId(int $id)
 	{
 		$this->_id = $id;

--- a/schema/traits/uuid.php
+++ b/schema/traits/uuid.php
@@ -1,0 +1,16 @@
+<?php
+namespace shgysk8zer0\PHPAPI\Schema\Traits;
+
+trait UUID
+{
+	final public static function generateUuid(): string
+	{
+		return sprintf('%04x%04x-%04x-%04x-%04x-%04x%04x%04x',
+			mt_rand(0, 0xffff), mt_rand(0,0xffff),
+			mt_rand(0, 0xffff),
+			mt_rand(0, 0x0fff) | 0x4000,
+			mt_rand(0, 0x3fff) | 0x8000,
+			mt_rand(0, 0xffff), mt_rand(0, 0xffff), mt_rand(0, 0xffff)
+		);
+	}
+}


### PR DESCRIPTION
- New essential classes & types
- More setters for existing classes
- Restructure to work with MySQL foreign keys
- All `_setData` now makes use of own class setters
- Add UUID, working `delete` method, and update `create` interface
- `InputData` now returns `self` when getting array/object values
- Handle `id`s for all schema classes