### PR TITLE
Dynamically set permissions per role

### DIFF
--- a/schema/abstracts/schema.php
+++ b/schema/abstracts/schema.php
@@ -2,15 +2,14 @@
 namespace shgysk8zer0\PHPAPI\Schema\Abstracts;
 
 use \JSONSerializable;
-use \shgysk8zer0\PHPAPI\{PDO, URL, Headers};
+use \shgysk8zer0\PHPAPI\{PDO, URL, Headers, UUID};
 use \shgysk8zer0\PHPAPI\Interfaces\{InputData};
 use \shgysk8zer0\PHPAPI\Schema\Interfaces\{Schema as SchemaInterface};
-use \shgysk8zer0\PHPAPI\Schema\Traits\{Schema as SchemaTrait, UUID};
+use \shgysk8zer0\PHPAPI\Schema\Traits\{Schema as SchemaTrait};
 
 abstract class Schema implements JSONSerializable, SchemaInterface
 {
 	use SchemaTrait;
-	use UUID;
 
 	const CONTEXT = 'https://schema.org/';
 
@@ -48,14 +47,23 @@ abstract class Schema implements JSONSerializable, SchemaInterface
 		}
 	}
 
-	final public function getScript(): string
-	{
-		return sprintf('<script type="%s">%s</script>', self::CONTENT_TYPE, json_encode($this));
-	}
-
 	final public function __toString(): string
 	{
 		return $this->getScript();
+	}
+
+	final public function getScript(): string
+	{
+		return sprintf(
+			'<script type="%s">%s</script>',
+			self::CONTENT_TYPE,
+			json_encode($this)
+		);
+	}
+
+	final public static function generateUuid(): string
+	{
+		return new UUID();
 	}
 
 	final public static function getSchemaURL(): string

--- a/uuid.php
+++ b/uuid.php
@@ -1,0 +1,28 @@
+<?php
+namespace shgysk8zer0\PHPAPI;
+
+final class UUID implements \JSONSerializable
+{
+	private $_uuid;
+
+	final public function __construct()
+	{
+		$this->_uuid = sprintf('%04x%04x-%04x-%04x-%04x-%04x%04x%04x',
+			mt_rand(0, 0xffff), mt_rand(0,0xffff),
+			mt_rand(0, 0xffff),
+			mt_rand(0, 0x0fff) | 0x4000,
+			mt_rand(0, 0x3fff) | 0x8000,
+			mt_rand(0, 0xffff), mt_rand(0, 0xffff), mt_rand(0, 0xffff)
+		);
+	}
+
+	final public function __toString()
+	{
+		return $this->_uuid;
+	}
+
+	final public function jsonSerialize(): string
+	{
+		return $this->_uuid;
+	}
+}


### PR DESCRIPTION
Permissions are now set to any columns in `roles` table other than `id` & `name`