### PR TITLE
Upgrade linting

### DIFF
--- a/abstracts/loglevel.php
+++ b/abstracts/loglevel.php
@@ -16,14 +16,14 @@ abstract class LogLevel
     public const INFO      = 'info';
     public const DEBUG     = 'debug';
 
-		public const ALL_LEVELS = [
-			self::EMERGENCY,
-			self::ALERT,
-			self::CRITICAL,
-			self::ERROR,
-			self::WARNING,
-			self::NOTICE,
-			self::INFO,
-			self::DEBUG,
-		];
+	public const ALL_LEVELS = [
+		self::EMERGENCY,
+		self::ALERT,
+		self::CRITICAL,
+		self::ERROR,
+		self::WARNING,
+		self::NOTICE,
+		self::INFO,
+		self::DEBUG,
+	];
 }

--- a/lint.php
+++ b/lint.php
@@ -32,7 +32,7 @@ if (PHP_SAPI !== 'cli') {
 	$logger->registerErrorHandler();
 
 	$linter = new Linter($logger);
-	$linter->ignoreDirs('./.git', './docs', './.github');
+	$linter->ignoreDirs('./.git', './docs', './.github', './vendor');
 	$linter->scanExts('php');
 	$args = getopt('d:', ['dir:']);
 

--- a/lint.php
+++ b/lint.php
@@ -1,20 +1,50 @@
 <?php
 namespace shgysk8zer0\PHPAPI;
 use \shgysk8zer0\PHPAPI\{Linter};
-
+use \LogicException;
 const BASE = __DIR__ . DIRECTORY_SEPARATOR;
 
 if (PHP_SAPI !== 'cli') {
 	http_response_code(403);
 	exit();
+} elseif (! isset($argv) or ! is_array($argv) or realpath($argv[0])!== __FILE__) {
+	throw new LogicException('Linter must be called directly');
 } else {
+	// Load required files
+	require_once BASE . 'abstracts/loglevel.php';
+	require_once BASE . 'traits/loggerawaretrait.php';
+	require_once BASE . 'interfaces/loggerawareinterface.php';
+	require_once BASE . 'interfaces/loggerinterface.php';
+	require_once BASE . 'traits/loggertrait.php';
+	require_once BASE . 'traits/splobserverloggertrait.php';
+	require_once BASE . 'traits/exceptionloggertrait.php';
+	require_once BASE . 'traits/singleton.php';
+	require_once BASE . 'traits/sapiloggertrait.php';
+	require_once BASE . 'abstracts/abstractlogger.php';
+	require_once BASE . 'nulllogger.php';
+	require_once BASE . 'traits/loggerinterpolatortrait.php';
+	require_once BASE . 'sapilogger.php';
 	require_once BASE . 'linter.php';
 	require_once BASE . 'shims.php';
-	$linter = new Linter();
+
+	$logger = new SAPILogger();
+	$logger->registerExceptionHandler();
+	$logger->registerErrorHandler();
+
+	$linter = new Linter($logger);
 	$linter->ignoreDirs('./.git', './docs', './.github');
 	$linter->scanExts('php');
+	$args = getopt('d:', ['dir:']);
 
-	if (! $linter->scan(__DIR__)) {
+	if (array_key_exists('dir', $args)) {
+		$dir = $args['dir'];
+	} elseif (array_key_exists('d', $args)) {
+		$dir = $args['d'];
+	} else {
+		$dir = __DIR__;
+	}
+
+	if (! $linter->scan($dir)) {
 		exit(1);
 	}
 }

--- a/linter.php
+++ b/linter.php
@@ -1,13 +1,33 @@
 <?php
 
 namespace shgysk8zer0\PHPAPI;
-use \FilesystemIterator as FS;
 
-final class Linter
+use \shgysk8zer0\PHPAPI\{NullLogger};
+use \shgysk8zer0\PHPAPI\Traits\{LoggerAwareTrait};
+use \shgysk8zer0\PHPAPI\Interfaces\{LoggerAwareInterface, LoggerInterface};
+use \FilesystemIterator as FS;
+use \InvalidArgumentException;
+use \RuntimeException;
+use \Throwable;
+
+final class Linter implements LoggerAwareInterface
 {
+	use LoggerAwareTrait;
+
 	private $_scan_exts    = ['php', 'phtml'];
 
 	private $_ignored_dirs = [];
+
+	public function __construct(?LoggerInterface $logger = null)
+	{
+		if (! function_exists('php_check_syntax')) {
+			throw new RuntimeException('`php_check_syntax` function not available');
+		} elseif (isset($logger)) {
+			$this->setLogger($logger);
+		} else {
+			$this->setLogger(new NullLogger());
+		}
+	}
 
 	final public function ignoreDirs(string ...$dirs): void
 	{
@@ -28,7 +48,8 @@ final class Linter
 
 	final public function isAllowedDir(FS $path): bool
 	{
-		return $path->isDir() and ! in_array($path->getPathname(), $this->_ignored_dirs);
+		// $this->logger->notice('Checking {path}', ['path' => $path->getPathName()]);
+		return $path->isDir() and ! in_array(realpath($path->getPathname()), $this->_ignored_dirs);
 	}
 
 	final public function isLintable(FS $path): bool
@@ -44,16 +65,17 @@ final class Linter
 
 			foreach ($dir as $path => $fs) {
 				if ($this->isAllowedDir($fs)) {
-					static::scan($path);
+					$valid = $this->scan($path) && $valid;
 				} elseif ($this->isLintable($fs)) {
-					if (! $this->lintFile($fs)) {
-						$valid = false;
-					}
+					$valid = $this->lintFile($fs) && $valid;
+				} elseif ($fs->isDir()) {
+					$this->logger->info('Ignoring {path}', ['path' => $path]);
 				}
 			}
+
 			return $valid;
 		} else {
-			throw new \InvalidArgumentException(sprintf('%s is not a directory', $path));
+			throw new InvalidArgumentException(sprintf('%s is not a directory', $path));
 		}
 	}
 
@@ -62,14 +84,30 @@ final class Linter
 		$valid = true;
 
 		if ($this->isLintable($path)) {
+			$this->logger->info('Linting file: {file}', ['file' => $path]);
 			$msg = '';
-			if (! php_check_syntax($path->getPathname(), $msg)) {
+			try {
+				if (! @php_check_syntax($path->getPathname(), $msg)) {
+					$valid = false;
+					$this->logger->error('Error in {file} with message {msg}', [
+						'file' => $path,
+						'msg'  => $msg,
+					]);
+				}
+			} catch (Throwable $e) {
 				$valid = false;
-				echo $msg . PHP_EOL;
+				$this->logger->error('[{type} {code}] "{message}" at {file}:{line}', [
+					'type'    => get_class($e),
+					'code'    => $e->getCode(),
+					'message' => $e->getMessage(),
+					'file'    => $e->getFile(),
+					'line'    => $e->getLine(),
+				]);
+			} finally {
+				return $valid;
 			}
-			return $valid;
 		} else {
-			throw new \InvalidArgumentException(sprintf('Cannot lint path: %s', $path->getPathne()));
+			throw new InvalidArgumentException(sprintf('Cannot lint path: %s', $path->getPathne()));
 		}
 	}
 }

--- a/shims.php
+++ b/shims.php
@@ -44,7 +44,7 @@ if (! function_exists('php_check_syntax')) {
 	function php_check_syntax(string $filename, string &$error_message = ''): bool
 	{
 		$cmd = sprintf('php -l %s', escapeshellarg($filename));
-		$error_message = exec($cmd, $output, $ret);
+		$error_message = @exec($cmd, $output, $ret);
 		return $ret === 0;
 	}
 }


### PR DESCRIPTION
Major rewrite of lint script.

- Use logging
- Ensure lint script is called directly
- Allow CLI args to specify directory to lint
- Linter class now throws if `php_check_syntax` does not exist