### PR TITLE
Add basic template class for HTML template files

### DIFF
--- a/template.php
+++ b/template.php
@@ -32,8 +32,8 @@ class Template
 		bool   $use_include_path = self::USE_INCLUDE_PATH,
 		string $left_enclosure   = null,
 		string $right_enclsure   = null,
-		string $charset          = null,
 		bool   $html_escape      = null,
+		string $charset          = null,
 		bool   $trim             = null,
 		bool   $nl_to_br         = null,
 		bool   $strip_comments   = null
@@ -49,10 +49,10 @@ class Template
 		if (isset($left_enclosure))  $this->_left_enclosure = $left_enclosure;
 		if (isset($right_enclosure)) $this->_right_enclosure = $right_enclosure;
 
-		if (! $this->_openFile($filename, $use_include_path)) {
-			throw new InvalidArgumentException(sprintf('Could not locate template file: "%s"', $filename));
-		} else {
+		if ($this->_openFile($filename, $use_include_path)) {
 			$this->_filename = $filename;
+		} else {
+			throw new InvalidArgumentException(sprintf('Could not locate template file: "%s"', $filename));
 		}
 	}
 

--- a/template.php
+++ b/template.php
@@ -7,37 +7,23 @@ class Template
 {
 	use TemplateTrait;
 
-	private const LEFT_ENCLOSURE  = '{{';
+	private const ESCAPE_FLAGS     = ENT_COMPAT | ENT_HTML5;
 
-	private const RIGHT_ENCLOSURE = '}}';
+	private const USE_INCLUDE_PATH = false;
 
-	public const CHARSET          = 'UTF-8';
+	private $_charset         = 'UTF-8';
 
-	public const ESCAPE_FLAGS     = ENT_COMPAT | ENT_HTML5;
+	private $_html_escape     = true;
 
-	public const HTML_ESCAPE      = true;
+	private $_left_enclosure  = '{{';
 
-	public const STRIP_COMMENTS   = true;
+	private $_right_enclosure = '}}';
 
-	public const USE_INCLUDE_PATH = false;
+	private $_nl_to_br        = false;
 
-	public const TRIM             = false;
+	private $_strip_comments  = true;
 
-	public const NL_TO_BR         = false;
-
-	private $_charset         = self::CHARSET;
-
-	private $_html_escape     = self::HTML_ESCAPE;
-
-	private $_left_enclosure  = self::LEFT_ENCLOSURE;
-
-	private $_right_enclosure = self::RIGHT_ENCLOSURE;
-
-	private $_nl_to_br        = self::NL_TO_BR;
-
-	private $_strip_comments  = self::STRIP_COMMENTS;
-
-	private $_trim            = self::TRIM;
+	private $_trim            = false;
 
 	private $_filename        = null;
 
@@ -63,9 +49,8 @@ class Template
 		if (isset($left_enclosure))  $this->_left_enclosure = $left_enclosure;
 		if (isset($right_enclosure)) $this->_right_enclosure = $right_enclosure;
 
-		$this->_filename = $filename;
-
 		if (! $this->_openFile($filename, $use_include_path)) {
+			$this->_filename = $filename;
 			throw new InvalidArgumentException(sprintf('Could not locate template file: "%s"', $filename));
 		}
 	}
@@ -73,28 +58,14 @@ class Template
 	public function __debugInfo(): array
 	{
 		return [
-			'filename' => $this->_filename,
+			'filename' => $this->getFilename(),
 			'data'     => $this->_getData(),
 		];
 	}
 
 	public function __toString(): string
 	{
-		$content = $this->stringify();
-
-		if ($this->_strip_comments) {
-			$content = $this->_stripComments($content);
-		}
-
-		if ($this->_trim) {
-			$content = str_replace(["\n", "\r", "\t"], [null, null, null], $content);
-		}
-
-		if ($this->_nl_to_br) {
-			$content = nl2br($content);
-		}
-
-		return trim($content) . PHP_EOL;
+		return $this->stringify($this->_strip_comments, $this->_trim, $this->_nl_to_br) . PHP_EOL;
 	}
 
 	final public function __isset(string $key): bool
@@ -115,6 +86,11 @@ class Template
 	final public function __set(string $key, string $value): void
 	{
 		$this->set($key, $value, $this->_html_escape, $this->_charset, self::ESCAPE_FLAGS);
+	}
+
+	final public function getFilename():? string
+	{
+		return $this->_filename;
 	}
 
 	final public function setCharset(string $val): void

--- a/template.php
+++ b/template.php
@@ -1,13 +1,15 @@
 <?php
 namespace shgysk8zer0\PHPAPI;
-
+use \shgysk8zer0\PHPAPI\Traits\TemplateTrait;
 use \InvalidArgumentException;
 
 class Template
 {
-	private const L = '{';
+	use TemplateTrait;
 
-	private const R = '}';
+	private const LEFT_ENCLOSURE  = '{{';
+
+	private const RIGHT_ENCLOSURE = '}}';
 
 	public const CHARSET          = 'UTF-8';
 
@@ -15,7 +17,7 @@ class Template
 
 	public const HTML_ESCAPE      = true;
 
-	public const STRIP_COMMENTS   = false;
+	public const STRIP_COMMENTS   = true;
 
 	public const USE_INCLUDE_PATH = false;
 
@@ -23,24 +25,26 @@ class Template
 
 	public const NL_TO_BR         = false;
 
-	private $_content        = '';
+	private $_charset         = self::CHARSET;
 
-	private $_charset        = self::CHARSET;
+	private $_html_escape     = self::HTML_ESCAPE;
 
-	private $_html_escape    = self::HTML_ESCAPE;
+	private $_left_enclosure  = self::LEFT_ENCLOSURE;
 
-	private $_nl_to_br       = self::NL_TO_BR;
+	private $_right_enclosure = self::RIGHT_ENCLOSURE;
 
-	private $_strip_comments = self::STRIP_COMMENTS;
+	private $_nl_to_br        = self::NL_TO_BR;
 
-	private $_trim           = self::TRIM;
+	private $_strip_comments  = self::STRIP_COMMENTS;
 
-	private $_data           = [];
+	private $_trim            = self::TRIM;
 
-	private $_filename       = null;
+	private $_filename        = null;
 
 	public function __construct(
 		string $filename,
+		string $left_enclosure   = null,
+		string $right_enclsure   = null,
 		bool   $use_include_path = self::USE_INCLUDE_PATH,
 		string $charset          = null,
 		bool   $html_escape      = null,
@@ -49,31 +53,37 @@ class Template
 		bool   $strip_comments   = null
 	)
 	{
-		if (isset($charset))        $this->setCharset($charset);
-		if (isset($html_escape))    $this->setHtmlEscape($html_escape);
-		if (isset($trim))           $this->setTrim($trim);
-		if (isset($nl_to_br))       $this->setNlToBr($nl_to_br);
-		if (isset($strip_comments)) $this->setStripComments($strip_comments);
+		if (isset($charset))         $this->setCharset($charset);
+		if (isset($html_escape))     $this->setHtmlEscape($html_escape);
+		if (isset($trim))            $this->setTrim($trim);
+		if (isset($nl_to_br))        $this->setNlToBr($nl_to_br);
+		if (isset($strip_comments))  $this->setStripComments($strip_comments);
 
-		if (! $this->_open($filename, $use_include_path)) {
+		// No setter methods for these because setting while in use wouldn't work out well
+		if (isset($left_enclosure))  $this->_left_enclosure = $left_enclosure;
+		if (isset($right_enclosure)) $this->_right_enclosure = $right_enclosure;
+
+		$this->_filename = $filename;
+
+		if (! $this->_openFile($filename, $use_include_path)) {
 			throw new InvalidArgumentException(sprintf('Could not locate template file: "%s"', $filename));
 		}
 	}
 
-	final public function __debugInfo(): array
+	public function __debugInfo(): array
 	{
 		return [
 			'filename' => $this->_filename,
-			'data'     => $this->_data,
+			'data'     => $this->_getData(),
 		];
 	}
 
-	final public function __toString(): string
+	public function __toString(): string
 	{
-		$content = strtr($this->_content, $this->_data);
+		$content = $this->stringify();
 
 		if ($this->_strip_comments) {
-			$content = $this->_removeComments($content);
+			$content = $this->_stripComments($content);
 		}
 
 		if ($this->_trim) {
@@ -89,30 +99,22 @@ class Template
 
 	final public function __isset(string $key): bool
 	{
-		return array_key_exists($this->_convert($key), $this->_data);
+		return $this->has($key);
 	}
 
 	final public function __unset(string $key): void
 	{
-		unset($this->_data[$this->_convert($key)]);
+		$this->remove($key);
 	}
 
 	final public function __get(string $key):? string
 	{
-		if (isset($this->{$key})) {
-			return $this->_data[$this->_convert($key)];
-		} else {
-			return null;
-		}
+		return $this->get($key);
 	}
 
 	final public function __set(string $key, string $value): void
 	{
-		if ($this->_html_escape) {
-			$this->_data[$this->_convert($key)] = htmlentities($value, self::ESCAPE_FLAGS, $this->_charset);
-		} else {
-			$this->_data[$this->_convert($key)] = $value;
-		}
+		$this->set($key, $value, $this->_html_escape, $this->_charset, self::ESCAPE_FLAGS);
 	}
 
 	final public function setCharset(string $val): void
@@ -145,25 +147,8 @@ class Template
 		return file_put_contents($filename, $this, LOCK_EX) !== false;
 	}
 
-	final private function _convert(string $key): string
+	final protected function _convert(string $key): string
 	{
-		return self::L . strtoupper($key) . self::R;
-	}
-
-	final protected function _open(string $filename, bool $use_include_path = false): bool
-	{
-		$this->_filename = $filename;
-		$content = @file_get_contents($filename, $use_include_path);
-
-		if (is_string($content)) {
-			$this->_content = $content;
-			return true;
-		} else {
-			return false;
-		}
-	}
-
-	final private function _removeComments(string $content) {
-		return preg_replace('/<!--(.|\s)*?-->/', '', $content);
+		return $this->_left_enclosure . strtoupper($key) . $this->_right_enclosure;
 	}
 }

--- a/template.php
+++ b/template.php
@@ -1,0 +1,169 @@
+<?php
+namespace shgysk8zer0\PHPAPI;
+
+use \InvalidArgumentException;
+
+class Template
+{
+	private const L = '{';
+
+	private const R = '}';
+
+	public const CHARSET          = 'UTF-8';
+
+	public const ESCAPE_FLAGS     = ENT_COMPAT | ENT_HTML5;
+
+	public const HTML_ESCAPE      = true;
+
+	public const STRIP_COMMENTS   = false;
+
+	public const USE_INCLUDE_PATH = false;
+
+	public const TRIM             = false;
+
+	public const NL_TO_BR         = false;
+
+	private $_content        = '';
+
+	private $_charset        = self::CHARSET;
+
+	private $_html_escape    = self::HTML_ESCAPE;
+
+	private $_nl_to_br       = self::NL_TO_BR;
+
+	private $_strip_comments = self::STRIP_COMMENTS;
+
+	private $_trim           = self::TRIM;
+
+	private $_data           = [];
+
+	private $_filename       = null;
+
+	public function __construct(
+		string $filename,
+		bool   $use_include_path = self::USE_INCLUDE_PATH,
+		string $charset          = null,
+		bool   $html_escape      = null,
+		bool   $trim             = null,
+		bool   $nl_to_br         = null,
+		bool   $strip_comments   = null
+	)
+	{
+		if (isset($charset))        $this->setCharset($charset);
+		if (isset($html_escape))    $this->setHtmlEscape($html_escape);
+		if (isset($trim))           $this->setTrim($trim);
+		if (isset($nl_to_br))       $this->setNlToBr($nl_to_br);
+		if (isset($strip_comments)) $this->setStripComments($strip_comments);
+
+		if (! $this->_open($filename, $use_include_path)) {
+			throw new InvalidArgumentException(sprintf('Could not locate template file: "%s"', $filename));
+		}
+	}
+
+	final public function __debugInfo(): array
+	{
+		return [
+			'filename' => $this->_filename,
+			'data'     => $this->_data,
+		];
+	}
+
+	final public function __toString(): string
+	{
+		$content = strtr($this->_content, $this->_data);
+
+		if ($this->_strip_comments) {
+			$content = $this->_removeComments($content);
+		}
+
+		if ($this->_trim) {
+			$content = str_replace(["\n", "\r", "\t"], [null, null, null], $content);
+		}
+
+		if ($this->_nl_to_br) {
+			$content = nl2br($content);
+		}
+
+		return trim($content) . PHP_EOL;
+	}
+
+	final public function __isset(string $key): bool
+	{
+		return array_key_exists($this->_convert($key), $this->_data);
+	}
+
+	final public function __unset(string $key): void
+	{
+		unset($this->_data[$this->_convert($key)]);
+	}
+
+	final public function __get(string $key):? string
+	{
+		if (isset($this->{$key})) {
+			return $this->_data[$this->_convert($key)];
+		} else {
+			return null;
+		}
+	}
+
+	final public function __set(string $key, string $value): void
+	{
+		if ($this->_html_escape) {
+			$this->_data[$this->_convert($key)] = htmlentities($value, self::ESCAPE_FLAGS, $this->_charset);
+		} else {
+			$this->_data[$this->_convert($key)] = $value;
+		}
+	}
+
+	final public function setCharset(string $val): void
+	{
+		$this->_charset = $val;
+	}
+
+	final public function setHtmlEscape(bool $val): void
+	{
+		$this->_html_escape = $val;
+	}
+
+	final public function setNlToBr(bool $val): void
+	{
+		$this->_nl_to_br = $val;
+	}
+
+	final public function setStripComments(bool $val): void
+	{
+		$this->_strip_comments = $val;
+	}
+
+	final public function setTrim(bool $val): void
+	{
+		$this->_trim = $val;
+	}
+
+	final public function saveAs(string $filename): bool
+	{
+		return file_put_contents($filename, $this, LOCK_EX) !== false;
+	}
+
+	final private function _convert(string $key): string
+	{
+		return self::L . strtoupper($key) . self::R;
+	}
+
+	final protected function _open(string $filename, bool $use_include_path = false): bool
+	{
+		$this->_filename = $filename;
+		$content = @file_get_contents($filename, $use_include_path);
+
+		if (is_string($content)) {
+			$this->_content = $content;
+			return true;
+		} else {
+			return false;
+		}
+	}
+
+	final private function _removeComments(string $content) {
+		return preg_replace('/<!--(.|\s)*?-->/', '', $content);
+	}
+}

--- a/template.php
+++ b/template.php
@@ -29,9 +29,9 @@ class Template
 
 	public function __construct(
 		string $filename,
+		bool   $use_include_path = self::USE_INCLUDE_PATH,
 		string $left_enclosure   = null,
 		string $right_enclsure   = null,
-		bool   $use_include_path = self::USE_INCLUDE_PATH,
 		string $charset          = null,
 		bool   $html_escape      = null,
 		bool   $trim             = null,
@@ -50,8 +50,9 @@ class Template
 		if (isset($right_enclosure)) $this->_right_enclosure = $right_enclosure;
 
 		if (! $this->_openFile($filename, $use_include_path)) {
-			$this->_filename = $filename;
 			throw new InvalidArgumentException(sprintf('Could not locate template file: "%s"', $filename));
+		} else {
+			$this->_filename = $filename;
 		}
 	}
 
@@ -118,9 +119,9 @@ class Template
 		$this->_trim = $val;
 	}
 
-	final public function saveAs(string $filename): bool
+	final public function saveAs(string $filename, int $flags = LOCK_EX): bool
 	{
-		return file_put_contents($filename, $this, LOCK_EX) !== false;
+		return file_put_contents($filename, $this, $flags) !== false;
 	}
 
 	final protected function _convert(string $key): string

--- a/traits/templatetrait.php
+++ b/traits/templatetrait.php
@@ -41,9 +41,23 @@ trait TemplateTrait
 		}
 	}
 
-	final public function stringify(): string
+	final public function stringify(bool $strip_comments = false, bool $trim = false, bool $nl_to_br): string
 	{
-		return strtr($this->_content, $this->_data);
+		$content = strtr($this->_content, $this->_data);
+
+		if ($strip_comments) {
+			$content = $this->_stripComments($content);
+		}
+
+		if ($trim) {
+			$content = str_replace(["\n", "\r", "\t"], [null, null, null], $content);
+		}
+
+		if ($nl_to_br) {
+			$content = nl2br($content);
+		}
+
+		return trim($content);
 	}
 
 	final protected function _setContent(string $content): void

--- a/traits/templatetrait.php
+++ b/traits/templatetrait.php
@@ -1,0 +1,74 @@
+<?php
+namespace shgysk8zer0\PHPAPI\Traits;
+
+trait TemplateTrait
+{
+	private $_content = '';
+
+	private $_data    = [];
+
+	final public function has(string $key): bool
+	{
+		return array_key_exists($this->_convert($key), $this->_data);
+	}
+
+	final public function remove(string $key): void
+	{
+		unset($this->_data[$this->_convert($key)]);
+	}
+
+	final public function get(string $key):? string
+	{
+		if ($this->has($key)) {
+			return $this->_data[$this->_convert($key)];
+		} else {
+			return $this->_data[$this->_convert($key)];
+		}
+	}
+
+	final public function set(
+		string $key,
+		string $value,
+		bool   $html_escape = true,
+		string $charset     = 'UTF-8',
+		int    $flags       = ENT_COMPAT | ENT_HTML5
+	): void
+	{
+		if ($html_escape) {
+			$this->_data[$this->_convert($key)] = htmlentities($value, $flags, $charset);
+		} else {
+			$this->_data[$this->_convert($key)] = $value;
+		}
+	}
+
+	final public function stringify(): string
+	{
+		return strtr($this->_content, $this->_data);
+	}
+
+	final protected function _setContent(string $content): void
+	{
+		$this->_content = trim($content);
+	}
+
+	final protected function _getData(): array
+	{
+		return $this->_data;
+	}
+
+	final protected function _openFile(string $filename, bool $use_include_path = false): bool
+	{
+		if ($content = @file_get_contents($filename, $use_include_path)) {
+			$this->_setContent($content);
+			return true;
+		} else {
+			return false;
+		}
+	}
+
+	final protected function _stripComments(string $content) {
+		return preg_replace('/<!--(.|\s)*?-->/', '', $content);
+	}
+
+	abstract protected function _convert(string $key): string;
+}

--- a/traits/templatetrait.php
+++ b/traits/templatetrait.php
@@ -22,7 +22,7 @@ trait TemplateTrait
 		if ($this->has($key)) {
 			return $this->_data[$this->_convert($key)];
 		} else {
-			return $this->_data[$this->_convert($key)];
+			return null;
 		}
 	}
 
@@ -41,7 +41,11 @@ trait TemplateTrait
 		}
 	}
 
-	final public function stringify(bool $strip_comments = false, bool $trim = false, bool $nl_to_br): string
+	final public function stringify(
+		bool $strip_comments = false,
+		bool $trim           = false,
+		bool $nl_to_br
+	): string
 	{
 		$content = strtr($this->_content, $this->_data);
 


### PR DESCRIPTION
Allows filling in placeholder values in template files with optional HTML escaping (default), trimming newlines, converting newlines to `<br>`, stripping HTML comments.

Also includes/uses a trait for the base functionality with public methods for `get`, `set`, & `strigify`.