### PR TITLE
Add Trait for setting logger levels & trait/interface for classes to have caches set

### DIFF
--- a/consolelogger.php
+++ b/consolelogger.php
@@ -4,6 +4,7 @@ namespace shgysk8zer0\PHPAPI;
 use \shgysk8zer0\PHPAPI\Abstracts\{AbstractLogger, LogLevel};
 use \shgysk8zer0\PHPAPI\Traits\{
 	LoggerInterpolatorTrait,
+	LoggerLevelsTrait,
 	ExceptionLoggerTrait,
 	SPLObserverLoggerTrait,
 	Singleton,
@@ -15,36 +16,39 @@ use \InvalidArgumentException;
 class ConsoleLogger extends AbstractLogger implements SPLObserver
 {
 	use LoggerInterpolatorTrait;
+	use LoggerLevelsTrait;
 	use ExceptionLoggerTrait;
 	use SPLObserverLoggerTrait;
 	use Singleton;
 
 	public function log(string $level, string $message, array $context = []): void
 	{
-		$msg = $this->interpolate($message, $context);
+		if ($this->allowsLevel($level)) {
+			$msg = $this->interpolate($message, $context);
 
-		switch($level) {
-			case LogLevel::EMERGENCY:
-			case LogLevel::ALERT:
-			case LogLevel::CRITICAL:
-			case LogLevel::ERROR:
-				Console::error($msg);
-				break;
+			switch($level) {
+				case LogLevel::EMERGENCY:
+				case LogLevel::ALERT:
+				case LogLevel::CRITICAL:
+				case LogLevel::ERROR:
+					Console::error($msg);
+					break;
 
-			case LogLevel::WARNING:
-			case LogLevel::NOTICE:
-				Console::warn($msg);
-				break;
+				case LogLevel::WARNING:
+					Console::warn($msg);
+					break;
 
-			case LogLevel::INFO:
-				Console::info($msg);
-				break;
+				case LogLevel::NOTICE:
+				case LogLevel::INFO:
+					Console::info($msg);
+					break;
 
-			case LogLevel::DEBUG:
-				Console::log($msg);
-				break;
+				case LogLevel::DEBUG:
+					Console::log($msg);
+					break;
 
-			default: throw new InvalidArgumentException("Invalid log level: {$level}");
+				default: throw new InvalidArgumentException("Invalid log level: {$level}");
+			}
 		}
 	}
 }

--- a/filelogger.php
+++ b/filelogger.php
@@ -3,6 +3,7 @@ namespace shgysk8zer0\PHPAPI;
 
 use \shgysk8zer0\PHPAPI\Traits\{
 	LoggerInterpolatorTrait,
+	LoggerLevelsTrait,
 	SPLObserverLoggerTrait,
 };
 
@@ -14,6 +15,7 @@ use \InvalidArgumentException;
 class FileLogger extends AbstractLogger implements SPLObserver
 {
 	use LoggerInterpolatorTrait;
+	use LoggerLevelsTrait;
 	use SPLObserverLoggerTrait;
 
 	public const LOG_FILE = 'errors.log';
@@ -27,9 +29,9 @@ class FileLogger extends AbstractLogger implements SPLObserver
 
 	final public function log(string $level, string $message, array $context = []): void
 	{
-		if (! in_array($level, LogLevel::ALL_LEVELS)) {
+		if (! $this->validLevel($level)) {
 			throw new InvalidArgumentException(sprintf('Invalid log level: "%s"', $level));
-		} else {
+		} elseif ($this->allowsLevel($level)) {
 			$msg = sprintf('[%s] %s', $level, $this->interpolate($message, $context));
 			error_log($msg . PHP_EOL, 3, $this->_file);
 		}

--- a/interfaces/cacheawareinterface.php
+++ b/interfaces/cacheawareinterface.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace shgysk8zer0\PHPAPI\Interfaces;
+
+use \Serializable;
+
+/**
+ * Extend serializable to ensure that custom serialization is implemented
+ * to prevent cache itself from being cached
+ */
+interface CacheAwareInterface extends Serializable
+{
+	public function setCache(CacheInterface $cache): void;
+}

--- a/nullcache.php
+++ b/nullcache.php
@@ -1,0 +1,103 @@
+<?php
+
+namespace shgysk8zer0\PHPAPI;
+
+use \shgysk8zer0\PHPAPI\Interfaces\{CacheInterface};
+
+use \shgysk8zer0\PHPAPI\Traits\{CacheTrait};
+
+use \DateInterval;
+
+
+/**
+ * No-op implementation of CacheInterface.
+ *
+ * This class does not provide a cache, but rather can serve as a default cache
+ * for classes that allow setting custom caches, eliminating the need to check
+ * if a cache is set.
+ */
+class NullCache implements CacheInterface
+{
+	use CacheTrait;
+
+	/**
+	 * Fetches a value from the cache.
+	 *
+	 * @param string $key	 The unique key of this item in the cache.
+	 * @param mixed  $default Default value to return if the key does not exist.
+	 *
+	 * @return mixed The value of the item from the cache, or $default in case of cache miss.
+	 *
+	 * @throws \InvalidArgumentException
+	 *   MUST be thrown if the $key string is not a legal value.
+	 */
+	public function get(string $key, ?object $default = null):? object
+	{
+		return $default;
+	}
+
+	/**
+	 * Persists data in the cache, uniquely referenced by a key with an optional expiration TTL time.
+	 *
+	 * @param string				 $key   The key of the item to store.
+	 * @param mixed				  $value The value of the item to store. Must be serializable.
+	 * @param null|\DateInterval $ttl   Optional. The TTL value of this item. If no value is sent and
+	 *									  the driver supports TTL then the library may set a default value
+	 *									  for it or let the driver take care of that.
+	 *
+	 * @return bool True on success and false on failure.
+	 *
+	 * @throws \InvalidArgumentException
+	 *   MUST be thrown if the $key string is not a legal value.
+	 */
+	public function set(string $key, object $value, ?DateInterval $ttl = null): bool
+	{
+		return false;
+	}
+
+	/**
+	 * Delete an item from the cache by its unique key.
+	 *
+	 * @param string $key The unique cache key of the item to delete.
+	 *
+	 * @return bool True if the item was successfully removed. False if there was an error.
+	 *
+	 * @throws \InvalidArgumentException
+	 *   MUST be thrown if the $key string is not a legal value.
+	 */
+	public function delete(string $key): bool
+	{
+		return false;
+	}
+
+	/**
+	 * Wipes clean the entire cache's keys.
+	 *
+	 * @return bool True on success and false on failure.
+	 */
+	public function clear(): bool
+	{
+		return false;
+	}
+
+	/**
+	 * Determines whether an item is present in the cache.
+	 *
+	 * NOTE: It is recommended that has() is only to be used for cache warming type purposes
+	 * and not to be used within your live applications operations for get/set, as this method
+	 * is subject to a race condition where your has() will return true and immediately after,
+	 * another script can remove it, making the state of your app out of date.
+	 *
+	 * @param string $key The cache item key.
+	 *
+	 * @return bool
+	 *
+	 * @throws \InvalidArgumentException
+	 *   MUST be thrown if the $key string is not a legal value.
+	 */
+	public function has(string $key): bool
+	{
+		return false;
+	}
+}
+

--- a/template.php
+++ b/template.php
@@ -28,7 +28,7 @@ class Template implements Serializable
 
 	private $_filename         = null;
 
-	private $_use_include_path = USE_INCLUDE_PATH;
+	private $_use_include_path = self::USE_INCLUDE_PATH;
 
 	public function __construct(
 		string $filename,

--- a/traits/cacheawaretrait.php
+++ b/traits/cacheawaretrait.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace shgysk8zer0\PHPAPI\Traits;
+
+use \shgysk8zer0\PHPAPI\Interfaces\{CacheInterface};
+
+trait CacheAwareTrait
+{
+	protected $cache = null;
+
+	final public function setCache(CacheInterface $cache): void
+	{
+		$this->cache = $cache;
+	}
+}

--- a/traits/exceptionloggertrait.php
+++ b/traits/exceptionloggertrait.php
@@ -14,6 +14,7 @@ trait ExceptionLoggerTrait
 	{
 		set_exception_handler([$this, 'logException']);
 	}
+
 	final public function logException(Throwable $e, string $level = LogLevel::ERROR): void
 	{
 		$this->log($level, '[{class} {code}] "{message}" at {file}:{line}', [

--- a/traits/loggerlevelstrait.php
+++ b/traits/loggerlevelstrait.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace shgysk8zer0\PHPAPI\Traits;
+
+use \shgysk8zer0\PHPAPI\Abstracts\LogLevel;
+
+use \InvalidArgumentException;
+
+trait LoggerLevelsTrait
+{
+	private $_levels = LogLevel::ALL_LEVELS;
+
+	final public function allowsLevel(string $level): bool
+	{
+		return in_array($level, $this->_levels);
+	}
+
+	final public function enableLevel(string $level): bool
+	{
+		if ($this->validLevel($level) and ! $this->allowsLevel($level)) {
+			$this->_levels[] = $level;
+			return true;
+		} else {
+			return false;
+		}
+	}
+
+	final public function disableLevel(string $level): bool
+	{
+		if ($this->validLevel($level) and $this->allowsLevel($level)) {
+			unset($this->_levels[array_search($level, $this->_levels)]);
+			return true;
+		} else {
+			return false;
+		}
+	}
+
+	final public function enableLevels(string ...$levels): void
+	{
+		foreach ($levels as $level) {
+			$this->enableLevel($level);
+		}
+	}
+
+	final public function disableLevels(string ...$levels): void
+	{
+		foreach ($levels as $level) {
+			$this->disableLevel($level);
+		}
+	}
+
+	final public function enableAllLevels(): void
+	{
+		$this->_levels = LogLevel::ALL_LEVELS;
+	}
+
+	final public function disableAllLevels(): void
+	{
+		$this->_levels = [];
+	}
+
+	final public function validLevel(string $level): bool
+	{
+		return in_array($level, LogLevel::ALL_LEVELS);
+	}
+}

--- a/traits/sapiloggertrait.php
+++ b/traits/sapiloggertrait.php
@@ -6,11 +6,13 @@ use \InvalidArgumentException;
 
 trait SAPILoggerTrait
 {
+	use LoggerLevelsTrait;
+
 	final public function log(string $level, string $message, array $context = []): void
 	{
-		if (! in_array($level, LogLevel::ALL_LEVELS)) {
+		if (! $this->validLevel($level)) {
 			throw new InvalidArgumentException(sprintf('Invalid log level: "%s"', $level));
-		} elseif (in_array(PHP_SAPI, ['cli', 'cli-server'])) {
+		} elseif ($this->allowsLevel($level) and in_array(PHP_SAPI, ['cli', 'cli-server'])) {
 			$msg = sprintf('[%s] "%s"', $level, $this->interpolate($message, $context));
 			error_log($msg, 4);
 		}

--- a/traits/systemloggertrait.php
+++ b/traits/systemloggertrait.php
@@ -6,11 +6,13 @@ use \InvalidArgumentException;
 
 trait SystemLoggerTrait
 {
+	use LoggerLevelsTrait;
+
 	final public function log(string $level, string $message, array $context = []): void
 	{
 		if (! in_array($level, LogLevel::ALL_LEVELS)) {
 			throw new InvalidArgumentException(sprintf('Invalid log level: "%s"', $level));
-		} else {
+		} elseif ($this->allowsLevel($level)) {
 			switch ($level) {
 				case LogLevel::EMERGENCY:
 					$lvl = LOG_EMERG;


### PR DESCRIPTION
- Provide trait and interface for caching within classes 
- Use provided methods to determine whether or not to log based on permitted log levels
- Provide default `CacheInterface` implementation

## Misc fixes
- Fix bad setting of `$_use_include_path` in `Template`
- Fix missing line break

Resolves #64 